### PR TITLE
fix: derive oracle address from private key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "availability-oracle"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "bytes 1.3.0",
@@ -132,6 +132,7 @@ dependencies = [
  "moka",
  "multibase",
  "reqwest",
+ "secp256k1",
  "serde",
  "serde_derive",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Subgraph Oracle verifies the availability of the subgraph files and does oth
 
 ```
 USAGE:
-    availability-oracle [FLAGS] [OPTIONS] --contracts <contracts> --ipfs <ipfs> --oracle <oracle> --signing-key <signing-key> --subgraph <subgraph>
+    availability-oracle [FLAGS] [OPTIONS] --contracts <contracts> --ipfs <ipfs> --signing-key <signing-key> --subgraph <subgraph>
 
 FLAGS:
         --dry-run    log the results but not send a transaction to the rewards manager
@@ -29,9 +29,6 @@ OPTIONS:
         --metrics-port <metrics-port>                    [env: ORACLE_METRICS_PORT=]  [default: 8090]
         --min-signal <min-signal>
             Minimum signal for a subgraph to be checked [env: ORACLE_MIN_SIGNAL=]  [default: 100]
-
-    -o, --oracle <oracle>
-            The address used by by the oracle to sign transactions [env: ORACLE_ADDRESS=]
 
         --period <period>
             How often the oracle should check the subgraphs. With the default value of 0, the oracle will run once and

--- a/availability-oracle/Cargo.toml
+++ b/availability-oracle/Cargo.toml
@@ -26,3 +26,4 @@ wasmparser = "0.74.0"
 multibase = "0.8.0"
 moka = { version = "0.8", features = ["future"] }
 graphql-parser = "0.4.0"
+secp256k1 = "0.20.3"

--- a/availability-oracle/src/main.rs
+++ b/availability-oracle/src/main.rs
@@ -12,6 +12,7 @@ use contract::*;
 use ipfs::*;
 use manifest::{Abi, DataSource, Manifest, Mapping};
 use network_subgraph::*;
+use secp256k1::key::SecretKey;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fmt::Display, str::FromStr};
@@ -19,7 +20,6 @@ use structopt::StructOpt;
 use tiny_cid::Cid;
 use tokio::time::MissedTickBehavior;
 use util::bytes32_to_cid_v0;
-use secp256k1::key::SecretKey;
 
 fn parse_secs(secs: &str) -> Result<Duration, Error> {
     Ok(Duration::from_secs(u64::from_str(secs)?))

--- a/availability-oracle/src/main.rs
+++ b/availability-oracle/src/main.rs
@@ -7,6 +7,7 @@ mod util;
 
 use common::prelude::*;
 use common::prometheus;
+use common::web3::signing::Key;
 use contract::*;
 use ipfs::*;
 use manifest::{Abi, DataSource, Manifest, Mapping};
@@ -18,6 +19,7 @@ use structopt::StructOpt;
 use tiny_cid::Cid;
 use tokio::time::MissedTickBehavior;
 use util::bytes32_to_cid_v0;
+use secp256k1::key::SecretKey;
 
 fn parse_secs(secs: &str) -> Result<Duration, Error> {
     Ok(Duration::from_secs(u64::from_str(secs)?))
@@ -95,15 +97,6 @@ struct Config {
     contracts: Option<common::contracts::ContractConfig>,
 
     #[structopt(
-        short,
-        long,
-        env = "ORACLE_ADDRESS",
-        required_unless("dry-run"),
-        help = "The address used by by the oracle to sign transactions"
-    )]
-    oracle: Option<Address>,
-
-    #[structopt(
         long,
         env = "ORACLE_SIGNING_KEY",
         required_unless("dry-run"),
@@ -151,10 +144,10 @@ async fn run(logger: Logger, config: Config) -> Result<()> {
     let subgraph = NetworkSubgraphImpl::new(logger.clone(), config.subgraph);
     let contract: Box<dyn RewardsManager> = match config.dry_run {
         false => {
-            let signing_key = &config.signing_key.unwrap().parse()?;
+            let signing_key: &SecretKey = &config.signing_key.unwrap().parse()?;
             let contracts_config = config.contracts.unwrap();
             let web3_context =
-                Web3Context::new(&contracts_config.url, config.oracle.unwrap(), signing_key)?;
+                Web3Context::new(&contracts_config.url, signing_key.address(), signing_key)?;
             let contracts = Contracts::new(contracts_config, web3_context);
             Box::new(RewardsManagerContract::new(contracts))
         }


### PR DESCRIPTION
We can derive the oracle address from the private key and remove the need to pass it in as another argument. This has recently caused some confusion as it seems we recently rotated the private key but not the address in the config.