### PR TITLE
feat: use epoch block oracle subgraph for supported networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
+        --epoch-block-oracle-subgraph <subgraph>
+            Graphql endpoint to the epoch block oracle subgraph used for fetching supported networks [env: EPOCH_BLOCK_ORACLE_SUBGRAPH=]
+
         --grace-period <grace-period>
             Grace period, in seconds from subgraph creation, for which subgraphs will not be checked [env: ORACLE_GRACE_PERIOD=]  [default: 0]
         
@@ -22,7 +25,7 @@ OPTIONS:
 
         --ipfs-timeout <ipfs-timeout>
             IPFS timeout after which a file will be considered unavailable [env: ORACLE_IPFS_TIMEOUT_SECS=]  [default: 30]
-        
+
         --metrics-port <metrics-port>
              [env: ORACLE_METRICS_PORT=]  [default: 8090]
 
@@ -49,9 +52,6 @@ OPTIONS:
 
         --supported-data-source-kinds <supported-data-source-kinds>...
             a comma separated list of the supported data source kinds [env: SUPPORTED_DATA_SOURCE_KINDS=]  [default: ethereum,ethereum/contract,file/ipfs,substreams,file/arweave]
-    
-    -s, --supported-networks <supported-networks>...
-            a comma separated list of the supported network ids [env: SUPPORTED_NETWORKS=]  [default: mainnet]
 
         --url <url>
             RPC url for the network [env: RPC_URL=]

--- a/availability-oracle/src/epoch_block_oracle_subgraph.rs
+++ b/availability-oracle/src/epoch_block_oracle_subgraph.rs
@@ -1,0 +1,116 @@
+use common::prelude::*;
+use futures::stream;
+use futures::Stream;
+use reqwest::Client;
+use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::pin::Pin;
+use std::sync::Arc;
+
+pub trait EpochBlockOracleSubgraph {
+    fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>>;
+}
+
+pub struct EpochBlockOracleSubgraphImpl {
+    logger: Logger,
+    endpoint: String,
+    client: Client,
+}
+
+impl EpochBlockOracleSubgraphImpl {
+    pub fn new(logger: Logger, endpoint: String) -> Arc<Self> {
+        Arc::new(EpochBlockOracleSubgraphImpl {
+            logger,
+            endpoint,
+            client: Client::new(),
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct GraphqlRequest {
+    query: String,
+    variables: BTreeMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct GraphqlResponse {
+    data: Option<BTreeMap<String, serde_json::Value>>,
+    errors: Option<Vec<serde_json::Value>>,
+}
+
+const SUPPORTED_NETWORKS_QUERY: &str = r#"
+query Networks($skip: Int!) {
+    networks(first: 1000, skip: $skip) {
+      id
+      alias
+    }
+  }
+"#;
+
+impl EpochBlockOracleSubgraph for EpochBlockOracleSubgraphImpl {
+    fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
+        stream::iter((0..).step_by(1000))
+            .then(move |skip| {
+                let this = self.clone();
+                async move {
+                    let req = GraphqlRequest {
+                        query: SUPPORTED_NETWORKS_QUERY.to_string(),
+                        variables: vec![("skip".to_string(), skip.into())]
+                            .into_iter()
+                            .collect(),
+                    };
+
+                    let res: GraphqlResponse = this
+                        .client
+                        .post(&this.endpoint)
+                        .json(&req)
+                        .send()
+                        .await?
+                        .error_for_status()?
+                        .json()
+                        .await?;
+
+                    if let Some(errs) = res.errors.filter(|errs| !errs.is_empty()) {
+                        return Err(anyhow!(
+                            "error querying supported networks from subgraph {}",
+                            serde_json::to_string(&errs)?
+                        ));
+                    }
+
+                    let data = res
+                        .data
+                        .ok_or_else(|| anyhow!("Data field is missing in the response"))?
+                        .remove("networks")
+                        .ok_or_else(|| anyhow!("'networks' field is missing in the data"))?;
+
+                    #[derive(Deserialize)]
+                    #[allow(non_snake_case)]
+                    struct RawNetwork {
+                        id: String,
+                        alias: String,
+                    }
+
+                    let page: Vec<RawNetwork> = serde_json::from_value(data)?;
+                    let page: Vec<String> = page
+                        .into_iter()
+                        .flat_map(|raw_network| vec![raw_network.id, raw_network.alias])
+                        .collect();
+
+                    trace!(this.logger, "networks page"; "page_size" => page.len());
+
+                    Ok(page)
+                }
+            })
+            .take_while(|networks| {
+                let keep_paginating = match networks {
+                    Ok(networks) => !networks.is_empty(),
+                    Err(_) => true,
+                };
+                async move { keep_paginating }
+            })
+            .map_ok(|networks| stream::iter(networks.into_iter().map(Ok)))
+            .try_flatten()
+            .boxed()
+    }
+}

--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -1,4 +1,5 @@
 use crate::contract;
+use crate::epoch_block_oracle_subgraph::*;
 use crate::ipfs::*;
 use crate::network_subgraph::*;
 use crate::util::bytes32_to_cid_v0;
@@ -51,7 +52,7 @@ async fn test_reconcile() {
         Arc::new(MockSubgraph),
         0,
         Duration::default(),
-        &vec!["mainnet".into()],
+        Arc::new(MockEBOSubgraph),
         &vec![
             "ethereum".into(),
             "ethereum/contract".into(),
@@ -92,6 +93,14 @@ impl NetworkSubgraph for MockSubgraph {
             new_subgraph(FILE_DS, false),
         ])
         .boxed()
+    }
+}
+
+struct MockEBOSubgraph;
+
+impl EpochBlockOracleSubgraph for MockEBOSubgraph {
+    fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
+        futures::stream::iter(vec![Ok("mainnet".to_string())]).boxed()
     }
 }
 


### PR DESCRIPTION
## Overview

Based on changes proposed in [PR #255](https://github.com/graphprotocol/block-oracle/pull/255) we will be able to use the Epoch Block Oracle Subgraph to get the list of supported networks instead of passing the list as a configuration parameter.

## Dependencies

This PR is dependent on the approval, merge and publish of [PR #255](https://github.com/graphprotocol/block-oracle/pull/255). The changes here should only be merged after PR #255 is successfully integrated and the updates are available.