### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrayref"
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -156,7 +156,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "common",
- "ethabi 18.0.0",
+ "ethabi",
  "ethers",
  "graphql-parser",
  "hex",
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+checksum = "30cca6d3674597c30ddf2c587bf8d9d65c9a84d2326d941cc79c9842dfe0ef52"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -323,9 +323,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -839,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -904,28 +904,11 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "17.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4966fba78396ff92db3b817ee71143eccd98acf0f876b8d600e585a670c5d1b"
-dependencies = [
- "ethereum-types 0.13.1",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3",
- "thiserror",
- "uint",
-]
-
-[[package]]
-name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
 dependencies = [
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "hex",
  "once_cell",
  "regex",
@@ -934,19 +917,6 @@ dependencies = [
  "sha3",
  "thiserror",
  "uint",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -956,26 +926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
-dependencies = [
- "ethbloom 0.12.1",
- "fixed-hash 0.7.0",
- "impl-rlp",
- "impl-serde 0.3.2",
- "primitive-types 0.11.1",
- "uint",
 ]
 
 [[package]]
@@ -984,21 +940,21 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
- "ethbloom 0.13.0",
- "fixed-hash 0.8.0",
+ "ethbloom",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
- "primitive-types 0.12.2",
+ "impl-serde",
+ "primitive-types",
  "scale-info",
  "uint",
 ]
 
 [[package]]
 name = "ethers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7cd562832e2ff584fa844cd2f6e5d4f35bbe11b28c7c9b8df957b2e1d0c701"
+checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1012,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35dc9a249c066d17e8947ff52a4116406163cf92c7f0763cb8c001760b26403f"
+checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1024,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43304317c7f776876e47f2f637859f6d0701c1ec7930a150f169d5fbe7d76f5a"
+checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1043,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f96502317bf34f6d71a3e3d270defaa9485d754d789e15a8e04a84161c95eb"
+checksum = "04ba01fbc2331a38c429eb95d4a570166781f14290ef9fdb144278a90b5a739b"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1067,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452ff6b0a64507ce8d67ffd48b1da3b42f03680dcf5382244e9c93822cbbf5de"
+checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1083,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1093,7 +1049,7 @@ dependencies = [
  "chrono",
  "const-hex",
  "elliptic-curve",
- "ethabi 18.0.0",
+ "ethabi",
  "generic-array",
  "k256",
  "num_enum",
@@ -1113,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d45b981f5fa769e1d0343ebc2a44cfa88c9bc312eb681b676318b40cef6fb1"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
@@ -1129,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145211f34342487ef83a597c1e69f0d3e01512217a7c72cc8a25931854c7dca0"
+checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1156,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6b15393996e3b8a78ef1332d6483c11d839042c17be58decc92fa8b1c3508a"
+checksum = "6434c9a33891f1effc9c75472e12666db2fa5a0fec4b29af6221680a6fe83ab2"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1193,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b125a103b56aef008af5d5fb48191984aa326b50bfd2557d231dc499833de3"
+checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1212,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.13"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
+checksum = "66244a771d9163282646dbeffe0e6eca4dda4146b6498644e678ac6089b11edd"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -1281,18 +1237,6 @@ checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -1810,15 +1754,6 @@ dependencies = [
 
 [[package]]
 name = "impl-serde"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
@@ -1945,7 +1880,7 @@ name = "json-oracle-encoder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ethabi 17.2.0",
+ "ethabi",
  "hex",
  "serde",
  "serde_json",
@@ -2257,15 +2192,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,7 +2215,7 @@ dependencies = [
  "arrayvec",
  "auto_impl",
  "bytes",
- "ethereum-types 0.14.1",
+ "ethereum-types",
  "open-fastrlp-derive",
 ]
 
@@ -2608,27 +2534,14 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec",
- "impl-rlp",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
- "fixed-hash 0.8.0",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.4.0",
+ "impl-serde",
  "scale-info",
  "uint",
 ]
@@ -3241,18 +3154,18 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3261,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -3408,11 +3321,11 @@ dependencies = [
 
 [[package]]
 name = "slog-term"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+checksum = "b6e022d0b998abfe5c3782c1f03551a596269450ccd677ea51c56f8b214610e8"
 dependencies = [
- "atty",
+ "is-terminal",
  "slog",
  "term",
  "thread_local",
@@ -3421,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
@@ -3532,18 +3445,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -3725,8 +3638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -3809,9 +3720,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4316,9 +4227,14 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmparser"
-version = "0.74.0"
+version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a4d63608421d9a22d4bce220f2841f3b609a5aaabd3ed3aeeb5fed2702c3c78"
+checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
+dependencies = [
+ "bitflags 2.4.2",
+ "indexmap 2.2.2",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"

--- a/availability-oracle/Cargo.toml
+++ b/availability-oracle/Cargo.toml
@@ -8,22 +8,22 @@ edition = "2018"
 
 [dependencies]
 common = { path = "../crates/common" }
-async-trait = "0.1.50"
-tokio = { version = "1.10", features = ["macros", "sync", "time"] }
+async-trait = "0.1.80"
+tokio = { version = "1.37.0", features = ["macros", "sync", "time"] }
 serde_yaml = "0.9.31"
-reqwest = { version = "0.11.4", features = ["json"] }
-serde_derive = "1.0.196"
-serde = "1.0.196"
-serde_json = "1.0.113"
+reqwest = { version = "0.11.24", features = ["json"] }
+serde_derive = "1.0.203"
+serde = "1.0.203"
+serde_json = "1.0.117"
 tiny-cid = "0.3"
-bytes = "1.0"
+bytes = "1.6.0"
 structopt = "0.3.18"
 hex = "0.4.2"
 ethabi = "18.0.0"
-wasmparser = "0.74.0"
+wasmparser = "0.201.0"
 multibase = "0.8.0"
 moka = { version = "0.12.5", features = ["future"] }
 graphql-parser = "0.4.0"
 secp256k1 = "0.28.2"
-ethers = "2.0.10"
+ethers = "2.0.14"
 url = "2.5.0"

--- a/availability-oracle/src/main.rs
+++ b/availability-oracle/src/main.rs
@@ -452,10 +452,9 @@ async fn check(
         for payload in wasmparser::Parser::new(0).parse_all(mapping) {
             if let Payload::ImportSection(s) = payload? {
                 for import in s {
-                    if let Some(field) = import?.field {
-                        if host_fn_prefixes.iter().any(|p| field.starts_with(p)) {
-                            return Ok(Some(field));
-                        }
+                    let name = import?.name;
+                    if host_fn_prefixes.iter().any(|p| name.starts_with(p)) {
+                        return Ok(Some(name));
                     }
                 }
             }

--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -1,165 +1,169 @@
-use crate::contract;
-use crate::epoch_block_oracle_subgraph::*;
-use crate::ipfs::*;
-use crate::network_subgraph::*;
-use crate::util::bytes32_to_cid_v0;
-use crate::util::cid_v0_to_bytes32;
-use async_trait::async_trait;
-use bytes::Bytes;
-use common::prelude::*;
-use futures::Stream;
-use std::sync::Arc;
-use std::time::Duration;
-use std::{pin::Pin, str::FromStr};
-use tiny_cid::Cid;
+#[cfg(test)]
+mod tests {
+    use crate::contract;
+    use crate::epoch_block_oracle_subgraph::*;
+    use crate::ipfs::*;
+    use crate::network_subgraph::*;
+    use crate::util::bytes32_to_cid_v0;
+    use crate::util::cid_v0_to_bytes32;
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use common::prelude::*;
+    use futures::Stream;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use std::{pin::Pin, str::FromStr};
+    use tiny_cid::Cid;
 
-const ZERO: &str = "QmWtzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-const ONE: &str = "QmWt111111111111111111111111111111111111111111";
-const TWO: &str = "QmWt222222222222222222222222222222222222222222";
-const THREE: &str = "QmWt333333333333333333333333333333333333333333";
-const FOUR: &str = "QmWt444444444444444444444444444444444444444444";
-const FIVE: &str = "QmWt555555555555555555555555555555555555555555";
-const SIX: &str = "QmWt666666666666666666666666666666666666666666";
-const SEVEN: &str = "QmWt777777777777777777777777777777777777777777";
-const SUBSTREAM: &str = "QmWt888888888888888888888888888888888888888888";
-const FILE_DS: &str = "QmWt999999999999999999999999999999999999999999";
+    const ZERO: &str = "QmWtzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const ONE: &str = "QmWt111111111111111111111111111111111111111111";
+    const TWO: &str = "QmWt222222222222222222222222222222222222222222";
+    const THREE: &str = "QmWt333333333333333333333333333333333333333333";
+    const FOUR: &str = "QmWt444444444444444444444444444444444444444444";
+    const FIVE: &str = "QmWt555555555555555555555555555555555555555555";
+    const SIX: &str = "QmWt666666666666666666666666666666666666666666";
+    const SEVEN: &str = "QmWt777777777777777777777777777777777777777777";
+    const SUBSTREAM: &str = "QmWt888888888888888888888888888888888888888888";
+    const FILE_DS: &str = "QmWt999999999999999999999999999999999999999999";
 
-const UNAVAILABLE_LINK: &str = "QmWt3unavzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const UNAVAILABLE_LINK: &str = "QmWt3unavzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 
-const VALID_WASM: &str = "QmWt3wasmzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-const VALID_ABI: &str = "QmWt3abizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-const INVALID_ABI: &str = "QmWt3badAbizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
-const VALID_SCHEMA: &str = "QmWt3schemazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const VALID_WASM: &str = "QmWt3wasmzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const VALID_ABI: &str = "QmWt3abizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const INVALID_ABI: &str = "QmWt3badAbizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
+    const VALID_SCHEMA: &str = "QmWt3schemazzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
 
-// Test the reconcile logic, mocking the data. Test subgraphs:
-// - ZERO - remains invalid
-// - ONE - remains valid
-// - TWO - becomes invalid due to missing manifest
-// - THREE - becomes invalid due to missing link `UNAVAILABLE_LINK`
-// - FOUR - becomes valid
-// - FIVE - becomes invalid due to invalid ABI
-// - SIX - becomes invalid due to invalid manifest
-// - SEVEN - becomes invalid due to non-mainnet network
-// - SUBSTREAM - becomes invalid due to `kind: substream`
-// - FILE_DS - remains valid
+    // Test the reconcile logic, mocking the data. Test subgraphs:
+    // - ZERO - remains invalid
+    // - ONE - remains valid
+    // - TWO - becomes invalid due to missing manifest
+    // - THREE - becomes invalid due to missing link `UNAVAILABLE_LINK`
+    // - FOUR - becomes valid
+    // - FIVE - becomes invalid due to invalid ABI
+    // - SIX - becomes invalid due to invalid manifest
+    // - SEVEN - becomes invalid due to non-mainnet network
+    // - SUBSTREAM - becomes invalid due to `kind: substream`
+    // - FILE_DS - remains valid
 
-#[tokio::test]
-async fn test_reconcile() {
-    crate::reconcile_deny_list(
-        &common::logging::create_logger(),
-        &MockIpfs,
-        &MockStateManager,
-        Arc::new(MockSubgraph),
-        0,
-        Duration::default(),
-        Arc::new(MockEBOSubgraph),
-        &vec![
-            "ethereum".into(),
-            "ethereum/contract".into(),
-            "file/ipfs".into(),
-            "substreams".into(),
-        ],
-    )
-    .await
-    .unwrap()
-}
-
-struct MockSubgraph;
-
-impl NetworkSubgraph for MockSubgraph {
-    fn deployments_over_threshold(
-        self: Arc<Self>,
-        _curation_threshold: u64,
-        _grace_period: Duration,
-    ) -> Pin<Box<dyn Stream<Item = Result<SubgraphDeployment, Error>>>> {
-        let new_subgraph = |id, deny| {
-            let id = cid_v0_to_bytes32(&Cid::from_str(id).unwrap());
-            Ok(SubgraphDeployment {
-                id,
-                signal_amount: 0,
-                deny,
-            })
-        };
-        futures::stream::iter(vec![
-            new_subgraph(ZERO, true),
-            new_subgraph(ONE, false),
-            new_subgraph(TWO, false),
-            new_subgraph(THREE, false),
-            new_subgraph(FOUR, true),
-            new_subgraph(FIVE, false),
-            new_subgraph(SIX, false),
-            new_subgraph(SEVEN, false),
-            new_subgraph(SUBSTREAM, false),
-            new_subgraph(FILE_DS, false),
-        ])
-        .boxed()
+    #[tokio::test]
+    async fn test_reconcile() {
+        crate::reconcile_deny_list(
+            &common::logging::create_logger(),
+            &MockIpfs,
+            &MockStateManager,
+            Arc::new(MockSubgraph),
+            0,
+            Duration::default(),
+            Arc::new(MockEBOSubgraph),
+            &vec![
+                "ethereum".into(),
+                "ethereum/contract".into(),
+                "file/ipfs".into(),
+                "substreams".into(),
+            ],
+        )
+        .await
+        .unwrap()
     }
-}
 
-struct MockEBOSubgraph;
+    struct MockSubgraph;
 
-impl EpochBlockOracleSubgraph for MockEBOSubgraph {
-    fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
-        futures::stream::iter(vec![Ok("mainnet".to_string())]).boxed()
-    }
-}
-
-struct MockIpfs;
-
-#[async_trait]
-impl Ipfs for MockIpfs {
-    /// Download a file.
-    async fn cat(&self, cid: Cid) -> Result<Bytes, IpfsError> {
-        let valid_manifest = include_bytes!("test_files/valid.yaml").to_vec().into();
-        match cid.to_string().as_str() {
-            ZERO => Err(IpfsError::ClientTimeout(cid, Error::msg("zero"))),
-            ONE => Ok(valid_manifest),
-            TWO => Err(IpfsError::ClientTimeout(cid, Error::msg("two"))),
-            THREE => Ok(include_bytes!("test_files/three.yaml").to_vec().into()),
-            FOUR => Ok(valid_manifest),
-            FIVE => Ok(include_bytes!("test_files/five.yaml").to_vec().into()),
-            SIX => Ok("@".as_bytes().into()), // An invalid manifest.
-            SEVEN => Ok(include_bytes!("test_files/seven.yaml").to_vec().into()),
-            SUBSTREAM => Ok(include_bytes!("test_files/substream.yaml").to_vec().into()),
-            FILE_DS => Ok(include_bytes!("test_files/file_ds.yaml").to_vec().into()),
-
-            UNAVAILABLE_LINK => Err(IpfsError::ClientTimeout(cid, Error::msg("unavail"))),
-
-            VALID_WASM => Ok(include_bytes!("test_files/Contract.wasm").to_vec().into()),
-            VALID_ABI => Ok(include_bytes!("test_files/Contract.abi").to_vec().into()),
-            VALID_SCHEMA => Ok(include_bytes!("test_files/schema.graphql").to_vec().into()),
-            INVALID_ABI => Ok(include_bytes!("test_files/BadContract.abi").to_vec().into()),
-
-            _ => unreachable!("unknown cid"),
+    impl NetworkSubgraph for MockSubgraph {
+        fn deployments_over_threshold(
+            self: Arc<Self>,
+            _curation_threshold: u64,
+            _grace_period: Duration,
+        ) -> Pin<Box<dyn Stream<Item = Result<SubgraphDeployment, Error>>>> {
+            let new_subgraph = |id, deny| {
+                let id = cid_v0_to_bytes32(&Cid::from_str(id).unwrap());
+                Ok(SubgraphDeployment {
+                    id,
+                    signal_amount: 0,
+                    deny,
+                })
+            };
+            futures::stream::iter(vec![
+                new_subgraph(ZERO, true),
+                new_subgraph(ONE, false),
+                new_subgraph(TWO, false),
+                new_subgraph(THREE, false),
+                new_subgraph(FOUR, true),
+                new_subgraph(FIVE, false),
+                new_subgraph(SIX, false),
+                new_subgraph(SEVEN, false),
+                new_subgraph(SUBSTREAM, false),
+                new_subgraph(FILE_DS, false),
+            ])
+            .boxed()
         }
     }
 
-    fn invalidate_cache(&self) {
-        unreachable!("invalidate cache");
+    struct MockEBOSubgraph;
+
+    impl EpochBlockOracleSubgraph for MockEBOSubgraph {
+        fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
+            futures::stream::iter(vec![Ok("mainnet".to_string())]).boxed()
+        }
     }
-}
 
-struct MockStateManager;
+    struct MockIpfs;
 
-#[async_trait]
-impl contract::StateManager for MockStateManager {
-    async fn deny_many(&self, denied_status: Vec<([u8; 32], bool)>) -> Result<(), Error> {
-        let denied_status = denied_status
-            .into_iter()
-            .map(|(id, deny)| {
-                let id = bytes32_to_cid_v0(id).to_string();
-                (id, deny)
-            })
-            .collect::<Vec<_>>();
+    #[async_trait]
+    impl Ipfs for MockIpfs {
+        /// Download a file.
+        async fn cat(&self, cid: Cid) -> Result<Bytes, IpfsError> {
+            let valid_manifest = include_bytes!("test_files/valid.yaml").to_vec().into();
+            match cid.to_string().as_str() {
+                ZERO => Err(IpfsError::ClientTimeout(cid, Error::msg("zero"))),
+                ONE => Ok(valid_manifest),
+                TWO => Err(IpfsError::ClientTimeout(cid, Error::msg("two"))),
+                THREE => Ok(include_bytes!("test_files/three.yaml").to_vec().into()),
+                FOUR => Ok(valid_manifest),
+                FIVE => Ok(include_bytes!("test_files/five.yaml").to_vec().into()),
+                SIX => Ok("@".as_bytes().into()), // An invalid manifest.
+                SEVEN => Ok(include_bytes!("test_files/seven.yaml").to_vec().into()),
+                SUBSTREAM => Ok(include_bytes!("test_files/substream.yaml").to_vec().into()),
+                FILE_DS => Ok(include_bytes!("test_files/file_ds.yaml").to_vec().into()),
 
-        assert!(denied_status.len() == 6);
-        assert_eq!(denied_status[0], (TWO.to_string(), true));
-        assert_eq!(denied_status[1], (THREE.to_string(), true));
-        assert_eq!(denied_status[2], (FOUR.to_string(), false));
-        assert_eq!(denied_status[3], (FIVE.to_string(), true));
-        assert_eq!(denied_status[4], (SIX.to_string(), true));
-        assert_eq!(denied_status[5], (SEVEN.to_string(), true));
+                UNAVAILABLE_LINK => Err(IpfsError::ClientTimeout(cid, Error::msg("unavail"))),
 
-        Ok(())
+                VALID_WASM => Ok(include_bytes!("test_files/Contract.wasm").to_vec().into()),
+                VALID_ABI => Ok(include_bytes!("test_files/Contract.abi").to_vec().into()),
+                VALID_SCHEMA => Ok(include_bytes!("test_files/schema.graphql").to_vec().into()),
+                INVALID_ABI => Ok(include_bytes!("test_files/BadContract.abi").to_vec().into()),
+
+                _ => unreachable!("unknown cid"),
+            }
+        }
+
+        fn invalidate_cache(&self) {
+            unreachable!("invalidate cache");
+        }
     }
+
+    struct MockStateManager;
+
+    #[async_trait]
+    impl contract::StateManager for MockStateManager {
+        async fn deny_many(&self, denied_status: Vec<([u8; 32], bool)>) -> Result<(), Error> {
+            let denied_status = denied_status
+                .into_iter()
+                .map(|(id, deny)| {
+                    let id = bytes32_to_cid_v0(id).to_string();
+                    (id, deny)
+                })
+                .collect::<Vec<_>>();
+
+            assert!(denied_status.len() == 6);
+            assert_eq!(denied_status[0], (TWO.to_string(), true));
+            assert_eq!(denied_status[1], (THREE.to_string(), true));
+            assert_eq!(denied_status[2], (FOUR.to_string(), false));
+            assert_eq!(denied_status[3], (FIVE.to_string(), true));
+            assert_eq!(denied_status[4], (SIX.to_string(), true));
+            assert_eq!(denied_status[5], (SEVEN.to_string(), true));
+
+            Ok(())
+        }
+    }
+    
 }

--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -101,7 +101,9 @@ mod tests {
     struct MockEBOSubgraph;
 
     impl EpochBlockOracleSubgraph for MockEBOSubgraph {
-        fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
+        fn supported_networks(
+            self: Arc<Self>,
+        ) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>> {
             futures::stream::iter(vec![Ok("mainnet".to_string())]).boxed()
         }
     }
@@ -165,5 +167,4 @@ mod tests {
             Ok(())
         }
     }
-    
 }

--- a/availability-oracle/src/util.rs
+++ b/availability-oracle/src/util.rs
@@ -14,6 +14,7 @@ pub fn bytes32_to_cid_v0(bytes32: [u8; 32]) -> Cid {
 }
 
 // Panics if `cid` version is not v0.
+#[allow(dead_code)]
 pub fn cid_v0_to_bytes32(cid: &Cid) -> [u8; 32] {
     assert!(cid.version() == tiny_cid::Version::V0);
     let cid_bytes = cid.to_bytes();

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -7,16 +7,16 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.79"
-async-trait = "0.1.50"
+anyhow = "1.0.86"
+async-trait = "0.1.80"
 slog = { version = "2.5.2", features = ["release_max_level_trace", "max_level_trace"] }
-slog-term = "2.6.0"
+slog-term = "2.9.1"
 slog-async = "2.8.0"
 futures = { version="0.3.30", features=["compat"] }
 warp = "0.3.6"
 prometheus = "0.13.3"
-tokio = { version="1.10", features=["sync", "time", "rt-multi-thread"] }
+tokio = { version="1.37.0", features=["sync", "time", "rt-multi-thread"] }
 structopt = "0.3.14"
 never = "0.1.0"
 lazy_static = "1.4.0"
-blake3 = "1.5.0"
+blake3 = "1.5.1"

--- a/crates/json-oracle-encoder/Cargo.toml
+++ b/crates/json-oracle-encoder/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0.57"
-ethabi = "17.2.0"
+anyhow = "1.0.86"
+ethabi = "18.0.0"
 hex = "0.4.3"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1"
+serde = { version = "1.0.203", features = ["derive"] }
+serde_json = "1.0.117"


### PR DESCRIPTION
Fixes warning in `wasmparser` dependency

```
warning: the following packages contain code that will be rejected by a future version of Rust: wasmparser v0.74.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
  Installing /root/.cargo/bin/availability-oracle
```