### PR TITLE
feat: implement deployment cache to reduce IPFS request load

### DIFF
--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -12,6 +12,7 @@ mod tests {
     use futures::Stream;
     use std::sync::Arc;
     use std::time::Duration;
+    use std::time::SystemTime;
     use std::{pin::Pin, str::FromStr};
     use tiny_cid::Cid;
 
@@ -61,9 +62,10 @@ mod tests {
                 "file/ipfs".into(),
                 "substreams".into(),
             ],
+            vec![]
         )
         .await
-        .unwrap()
+        .unwrap();
     }
 
     struct MockSubgraph;

--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -12,7 +12,6 @@ mod tests {
     use futures::Stream;
     use std::sync::Arc;
     use std::time::Duration;
-    use std::time::SystemTime;
     use std::{pin::Pin, str::FromStr};
     use tiny_cid::Cid;
 

--- a/availability-oracle/src/test.rs
+++ b/availability-oracle/src/test.rs
@@ -61,7 +61,7 @@ mod tests {
                 "file/ipfs".into(),
                 "substreams".into(),
             ],
-            vec![]
+            vec![],
         )
         .await
         .unwrap();


### PR DESCRIPTION
Adds a "valid deployment cache", deployments that are deemed valid will be considered valid for 24 hrs and won't get checked during the SAO run. This eliminates unnecessary requests to IPFS. 

Note that there is also a cache at the IPFS cid level that gets cleared in between SAO runs. 