### PR TITLE
fix: use timeouts in all requests to subgraphs

### DIFF
--- a/availability-oracle/src/epoch_block_oracle_subgraph.rs
+++ b/availability-oracle/src/epoch_block_oracle_subgraph.rs
@@ -6,7 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::pin::Pin;
 use std::sync::Arc;
-
+use std::time::Duration;
 pub trait EpochBlockOracleSubgraph {
     fn supported_networks(self: Arc<Self>) -> Pin<Box<dyn Stream<Item = Result<String, Error>>>>;
 }
@@ -22,7 +22,10 @@ impl EpochBlockOracleSubgraphImpl {
         Arc::new(EpochBlockOracleSubgraphImpl {
             logger,
             endpoint,
-            client: Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .unwrap(),
         })
     }
 }

--- a/availability-oracle/src/ipfs.rs
+++ b/availability-oracle/src/ipfs.rs
@@ -3,6 +3,7 @@ use bytes::Bytes;
 use common::prelude::*;
 use common::prometheus;
 use moka::future::Cache;
+use reqwest::Client;
 use std::time::Duration;
 use tiny_cid::Cid;
 
@@ -25,7 +26,7 @@ pub trait Ipfs {
 pub struct IpfsImpl {
     endpoint: String,
     semaphore: tokio::sync::Semaphore,
-    client: reqwest::Client,
+    client: Client,
 
     // Cache for CIDs; we invalidate this cache between runs to ensure we're checking
     // IPFS regularly
@@ -38,7 +39,7 @@ pub struct IpfsImpl {
 impl IpfsImpl {
     pub fn new(endpoint: String, max_concurrent: usize, timeout: Duration) -> Self {
         IpfsImpl {
-            client: reqwest::Client::new(),
+            client: Client::new(),
             endpoint,
             semaphore: tokio::sync::Semaphore::new(max_concurrent),
             cache: Cache::new(10000),

--- a/availability-oracle/src/network_subgraph.rs
+++ b/availability-oracle/src/network_subgraph.rs
@@ -3,6 +3,7 @@ use common::prelude::*;
 use futures::stream;
 use futures::Stream;
 use multibase::Base;
+use reqwest::Client;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::pin::Pin;
@@ -39,7 +40,7 @@ pub trait NetworkSubgraph {
 pub struct NetworkSubgraphImpl {
     logger: Logger,
     endpoint: String,
-    client: reqwest::Client,
+    client: Client,
 }
 
 impl NetworkSubgraphImpl {
@@ -47,7 +48,10 @@ impl NetworkSubgraphImpl {
         Arc::new(NetworkSubgraphImpl {
             logger,
             endpoint,
-            client: reqwest::Client::new(),
+            client: Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .unwrap(),
         })
     }
 }


### PR DESCRIPTION
We already have timeouts in IPFS requests, but not subgraphs