### PR TITLE
fix: aborting entire reconciliation run on a single 401

### DIFF
--- a/availability-oracle/src/ipfs.rs
+++ b/availability-oracle/src/ipfs.rs
@@ -67,9 +67,6 @@ impl IpfsImpl {
                 }
                 _ if e.is_timeout() => IpfsError::ClientTimeout(cid, e.into()),
                 Some(NOT_FOUND) => IpfsError::NotFound(cid, e.into()),
-                // The gateway can refuse to serve a specific object (auth, denylist, or
-                // legal/removed content). This is object-specific, so treat it like a
-                // missing file rather than aborting the whole reconciliation.
                 Some(UNAUTHORIZED) | Some(FORBIDDEN) | Some(GONE) | Some(UNAVAILABLE_LEGAL) => {
                     IpfsError::Denied(cid, e.into())
                 }

--- a/availability-oracle/src/ipfs.rs
+++ b/availability-oracle/src/ipfs.rs
@@ -11,6 +11,7 @@ pub enum IpfsError {
     GatewayTimeout(Cid, Error), // Gateway/Cloudflare timed-out
     ClientTimeout(Cid, Error),  // Client timed-out when requesting the file
     NotFound(Cid, Error),       // Manifest not found
+    Denied(Cid, Error),         // Gateway refuses to serve this object (auth/denylist/removed)
     Other(Error),
 }
 
@@ -66,6 +67,12 @@ impl IpfsImpl {
                 }
                 _ if e.is_timeout() => IpfsError::ClientTimeout(cid, e.into()),
                 Some(NOT_FOUND) => IpfsError::NotFound(cid, e.into()),
+                // The gateway can refuse to serve a specific object (auth, denylist, or
+                // legal/removed content). This is object-specific, so treat it like a
+                // missing file rather than aborting the whole reconciliation.
+                Some(UNAUTHORIZED) | Some(FORBIDDEN) | Some(GONE) | Some(UNAVAILABLE_LEGAL) => {
+                    IpfsError::Denied(cid, e.into())
+                }
                 _ => IpfsError::Other(e.into()),
             })
     }
@@ -74,6 +81,10 @@ impl IpfsImpl {
 const CLOUDFLARE_TIMEOUT: u16 = 524;
 const GATEWAY_TIMEOUT: u16 = 504;
 const NOT_FOUND: u16 = 404;
+const UNAUTHORIZED: u16 = 401;
+const FORBIDDEN: u16 = 403;
+const GONE: u16 = 410;
+const UNAVAILABLE_LEGAL: u16 = 451;
 
 #[async_trait]
 impl Ipfs for IpfsImpl {

--- a/availability-oracle/src/main.rs
+++ b/availability-oracle/src/main.rs
@@ -572,6 +572,7 @@ impl From<IpfsError> for CheckError {
                 CheckError::Invalid(Invalid::Unavailable(cid, err))
             }
             IpfsError::NotFound(cid, err) => CheckError::Invalid(Invalid::Unavailable(cid, err)),
+            IpfsError::Denied(cid, err) => CheckError::Invalid(Invalid::Unavailable(cid, err)),
             IpfsError::Other(e) => CheckError::Other(e),
         }
     }


### PR DESCRIPTION
Fixes the availability oracle aborting an entire reconciliation run when the IPFS gateway returns a 401 for a single deployment. 
The error taxonomy predates the migration from the Kubo RPC endpoint to the public `ipfs.thegraph.com` gateway, so authorization/denylist responses (401/403/410/451) fell through to the fatal `Other` bucket instead of being handled per-object. These status codes are now treated like a missing file (`Unavailable`), isolating the failure to the affected deployment so the rest of the run completes and still updates the deny list on-chain.